### PR TITLE
CLI Direct hardware encoding

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /captures
 /.todo
+.direnv

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -88,6 +88,7 @@ fn update(
                 .expect("Failed to create MP4 encoder")
                 .with_framerate(30)
                 .with_crf(18)
+                .with_preset("p7".to_string())
             mp4_openh264::Mp4Openh264Encoder::new(
                 fs::File::create("captures/simple/simple_openh264.mp4").unwrap(),
                 512,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -85,8 +85,9 @@ fn update(
                 .with_repeat(gif::Repeat::Infinite),
             frames::FramesEncoder::new("captures/simple/frames"),
             mp4_ffmpeg_cli::Mp4FfmpegCliEncoder::new("captures/simple/simple_ffmpeg.mp4")
-                .unwrap()
-                .with_framerate(10),
+                .expect("Failed to create MP4 encoder")
+                .with_framerate(30)
+                .with_crf(18)
             mp4_openh264::Mp4Openh264Encoder::new(
                 fs::File::create("captures/simple/simple_openh264.mp4").unwrap(),
                 512,

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1758940228,
+        "narHash": "sha256-sTS04L9LKqzP1oiVXYDwcMzfFSF0DnSJQFzZBpEgLFE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "5bfedf3fbbf5caf8e39f7fcd62238f54d82aa1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  description = "A Bevy capture development flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , rust-overlay
+    , flake-utils
+    ,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system;
+          inherit overlays;
+        };
+
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        # Libraries needed at runtime
+        libraries = with pkgs; [
+          alsa-lib
+          vulkan-loader
+          libxkbcommon
+          libxkbcommon.dev # This provides libxkbcommon-x11.so
+          systemd
+          wayland
+          wayland-protocols
+          xorg.libX11
+          xorg.libXcursor
+          xorg.libXrandr
+          xorg.libXi
+        ];
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages =
+            with pkgs;
+            [
+              # Rust toolchain
+              rustToolchain
+
+              # Core Bevy Dependencies
+              pkg-config
+
+              # Video generation
+              ffmpeg-full
+            ]
+            ++ libraries;
+
+          # Set up library path for runtime
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath libraries;
+
+          # Alternative: you can also use shellHook to set the path
+          shellHook = ''
+          '';
+        };
+      }
+    );
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/src/encoder/mp4_ffmpeg_cli.rs
+++ b/src/encoder/mp4_ffmpeg_cli.rs
@@ -1,31 +1,43 @@
-//! MP4 encoder using ffmpeg CLI (ffmpeg must be in PATH).
+//! MP4 encoder using ffmpeg CLI with real-time streaming (ffmpeg must be in PATH).
 
 use super::{Encoder, Result};
 use bevy::prelude::*;
-use std::{path::PathBuf, process::Command};
-use tempdir::TempDir;
+use std::{
+    io::Write,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+};
 
-/// An encoder that encodes a sequence of images into an MP4 file using ffmpeg CLI.
+/// An encoder that streams frames directly to ffmpeg for real-time MP4 encoding.
 /// ffmpeg must be in PATH.
 pub struct Mp4FfmpegCliEncoder {
-    dir: TempDir,
-    frame: u32,
+    /// The ffmpeg child process
+    process: Option<Child>,
+
+    /// Output file path
     path: PathBuf,
 
+    /// Video configuration
     framerate: u32,
     crf: u32,
+
+    /// Hardware encoder preference (nvenc, vaapi, etc.)
+    hardware_encoder: Option<String>,
+
+    /// Video resolution (width, height)
+    resolution: Option<(u32, u32)>,
 }
 
 impl Mp4FfmpegCliEncoder {
     /// Creates a new MP4 encoder that writes the MP4 to the given path.
     pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
         Ok(Self {
-            dir: TempDir::new("bevy_capture")?,
-            frame: 0,
+            process: None,
             path: path.into(),
-
             framerate: 60,
             crf: 23,
+            hardware_encoder: None,
+            resolution: None,
         })
     }
 
@@ -40,47 +52,214 @@ impl Mp4FfmpegCliEncoder {
         self.crf = crf;
         self
     }
-}
 
-impl Encoder for Mp4FfmpegCliEncoder {
-    fn encode(&mut self, image: &Image) -> Result<()> {
-        let image = image.clone().try_into_dynamic()?;
-        image.save(self.dir.path().join(format!("frame_{:06}.png", self.frame)))?;
+    /// Sets hardware encoder (e.g., "h264_nvenc", "h264_vaapi", "h264_videotoolbox").
+    /// If the hardware encoder is not available, it will fallback to libx264.
+    pub fn with_hardware_encoder(mut self, encoder: impl Into<String>) -> Self {
+        self.hardware_encoder = Some(encoder.into());
+        self
+    }
 
-        self.frame += 1;
+    /// Explicitly sets the video resolution. If not set, resolution will be determined from the first frame.
+    pub fn with_resolution(mut self, width: u32, height: u32) -> Self {
+        self.resolution = Some((width, height));
+        self
+    }
+
+    /// Detects available hardware encoders on the system
+    pub fn detect_hardware_encoder() -> Option<String> {
+        // Try NVIDIA NVENC first
+        if Self::test_encoder("h264_nvenc") {
+            return Some("h264_nvenc".to_string());
+        }
+
+        // Try Intel Quick Sync Video
+        if Self::test_encoder("h264_qsv") {
+            return Some("h264_qsv".to_string());
+        }
+
+        // Try VAAPI (Linux)
+        if Self::test_encoder("h264_vaapi") {
+            return Some("h264_vaapi".to_string());
+        }
+
+        // Try VideoToolbox (macOS)
+        if Self::test_encoder("h264_videotoolbox") {
+            return Some("h264_videotoolbox".to_string());
+        }
+
+        None
+    }
+
+    /// Tests if a specific encoder is available
+    fn test_encoder(encoder: &str) -> bool {
+        Command::new("ffmpeg")
+            .args(["-hide_banner", "-encoders"])
+            .output()
+            .map(|output| String::from_utf8_lossy(&output.stdout).contains(encoder))
+            .unwrap_or(false)
+    }
+
+    /// Initializes the ffmpeg process with the first frame to determine video properties
+    fn initialize_process(&mut self, image: &Image) -> Result<()> {
+        let (width, height) = match self.resolution {
+            Some((w, h)) => (w, h),
+            None => (image.width(), image.height()),
+        };
+
+        // Choose encoder
+        let encoder = self
+            .hardware_encoder
+            .clone()
+            .or_else(|| Self::detect_hardware_encoder())
+            .unwrap_or_else(|| "libx264".to_string());
+
+        bevy::log::info!("Using encoder: {} for {}x{} video", encoder, width, height);
+
+        let mut command = Command::new("ffmpeg");
+
+        // Input settings
+        command.args([
+            "-y", // Overwrite output file
+            "-f",
+            "rawvideo", // Input format
+            "-pix_fmt",
+            "rgba", // Input pixel format (Bevy uses RGBA)
+            "-s",
+            &format!("{}x{}", width, height), // Input resolution
+            "-r",
+            &self.framerate.to_string(), // Input framerate
+            "-i",
+            "pipe:0", // Read from stdin
+        ]);
+
+        // Encoder settings
+        command.args(["-c:v", &encoder]);
+
+        // Pixel format for output
+        command.args(["-pix_fmt", "yuv420p"]);
+
+        // Quality settings - adjust based on encoder type
+        match encoder.as_str() {
+            "h264_nvenc" => {
+                command.args(["-preset", "fast"]);
+                command.args(["-cq", &self.crf.to_string()]);
+            }
+            "h264_qsv" => {
+                command.args(["-preset", "fast"]);
+                command.args(["-global_quality", &self.crf.to_string()]);
+            }
+            "h264_vaapi" => {
+                command.args(["-vaapi_device", "/dev/dri/renderD128"]);
+                command.args(["-qp", &self.crf.to_string()]);
+            }
+            "h264_videotoolbox" => {
+                command.args(["-q:v", &self.crf.to_string()]);
+            }
+            _ => {
+                // Default libx264 settings
+                command.args(["-preset", "fast"]);
+                command.args(["-crf", &self.crf.to_string()]);
+            }
+        }
+
+        // Output file
+        command.arg(&self.path);
+
+        // Set up pipes
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let child = command.spawn()?;
+        self.process = Some(child);
 
         Ok(())
     }
 
-    fn finish(self: Box<Self>) {
-        let mut command;
-        if cfg!(target_os = "windows") {
-            command = Command::new("cmd");
-            command.arg("/C");
-        } else {
-            command = Command::new("sh");
-            command.arg("-c");
-        };
+    /// Converts Bevy Image (RGBA) to raw bytes suitable for ffmpeg
+    fn image_to_raw_bytes(image: &Image) -> Result<Vec<u8>> {
+        // Bevy images are typically in RGBA format
+        let image_data = image.data.as_ref().ok_or("Image has no data")?;
 
-        command.arg("ffmpeg");
-        command.arg("-framerate").arg(self.framerate.to_string());
-        command
-            .arg("-i")
-            .arg(self.dir.path().join("frame_%06d.png"));
-        command.arg("-c:v").arg("libx264");
-        command.arg("-pix_fmt").arg("yuv420p");
-        command.arg("-crf").arg(self.crf.to_string());
-        command.arg(self.path);
+        // ffmpeg expects raw RGBA bytes
+        Ok(image_data.clone())
+    }
+}
 
-        match command.output() {
-            Ok(output) => {
-                if !output.status.success() {
-                    bevy::log::error!("ffmpeg failed: {:?}", output);
+impl Encoder for Mp4FfmpegCliEncoder {
+    fn encode(&mut self, image: &Image) -> Result<()> {
+        // Initialize process on first frame
+        if self.process.is_none() {
+            self.initialize_process(image)?;
+        }
+
+        // Get the stdin pipe
+        let process = self
+            .process
+            .as_mut()
+            .ok_or("FFmpeg process not initialized")?;
+
+        let stdin = process.stdin.as_mut().ok_or("Failed to get stdin pipe")?;
+
+        // Convert image to raw bytes and write to ffmpeg
+        let raw_bytes = Self::image_to_raw_bytes(image)?;
+        stdin.write_all(&raw_bytes)?;
+        stdin.flush()?;
+
+        Ok(())
+    }
+
+    fn finish(mut self: Box<Self>) {
+        if let Some(mut process) = self.process.take() {
+            // Close stdin to signal end of input
+            drop(process.stdin.take());
+
+            // Wait for process to complete
+            match process.wait() {
+                Ok(status) => {
+                    if status.success() {
+                        bevy::log::info!("Video encoding completed successfully: {:?}", self.path);
+                    } else {
+                        // Try to capture stderr for error details
+                        if let Some(mut stderr) = process.stderr.take() {
+                            use std::io::Read;
+                            let mut error_msg = String::new();
+                            if stderr.read_to_string(&mut error_msg).is_ok() {
+                                bevy::log::error!(
+                                    "FFmpeg failed with status {}: {}",
+                                    status,
+                                    error_msg
+                                );
+                            } else {
+                                bevy::log::error!("FFmpeg failed with status: {}", status);
+                            }
+                        } else {
+                            bevy::log::error!("FFmpeg failed with status: {}", status);
+                        }
+                    }
+                }
+                Err(error) => {
+                    bevy::log::error!("Failed to wait for FFmpeg process: {:?}", error);
                 }
             }
-            Err(error) => {
-                bevy::log::error!("ffmpeg failed: {:?}", error);
-            }
+        }
+    }
+}
+
+impl Drop for Mp4FfmpegCliEncoder {
+    fn drop(&mut self) {
+        if let Some(mut process) = self.process.take() {
+            // Attempt graceful shutdown
+            drop(process.stdin.take());
+
+            // Give it a moment to finish
+            std::thread::sleep(std::time::Duration::from_millis(100));
+
+            // Force kill if still running
+            let _ = process.kill();
+            let _ = process.wait();
         }
     }
 }

--- a/src/encoder/mp4_ffmpeg_cli.rs
+++ b/src/encoder/mp4_ffmpeg_cli.rs
@@ -20,6 +20,7 @@ pub struct Mp4FfmpegCliEncoder {
     /// Video configuration
     framerate: u32,
     crf: u32,
+    preset: Option<String>,
 
     /// Hardware encoder preference (nvenc, vaapi, etc.)
     hardware_encoder: Option<String>,
@@ -36,6 +37,7 @@ impl Mp4FfmpegCliEncoder {
             path: path.into(),
             framerate: 60,
             crf: 23,
+            preset: Some("fast".to_string()),
             hardware_encoder: None,
             resolution: None,
         })
@@ -50,6 +52,12 @@ impl Mp4FfmpegCliEncoder {
     /// Sets the CRF (Constant Rate Factor) of the video.
     pub fn with_crf(mut self, crf: u32) -> Self {
         self.crf = crf;
+        self
+    }
+    
+    /// Sets the preset of the video.
+    pub fn with_preset(mut self, preset: impl Into<String>) -> Self {
+        self.preset = Some(preset.into());
         self
     }
 
@@ -106,6 +114,9 @@ impl Mp4FfmpegCliEncoder {
             Some((w, h)) => (w, h),
             None => (image.width(), image.height()),
         };
+        
+        // Preset
+        let preset = self.preset.as_deref().unwrap();
 
         // Choose encoder
         let encoder = self
@@ -142,11 +153,11 @@ impl Mp4FfmpegCliEncoder {
         // Quality settings - adjust based on encoder type
         match encoder.as_str() {
             "h264_nvenc" => {
-                command.args(["-preset", "fast"]);
+                command.args(["-preset", preset]);
                 command.args(["-cq", &self.crf.to_string()]);
             }
             "h264_qsv" => {
-                command.args(["-preset", "fast"]);
+                command.args(["-preset", preset]);
                 command.args(["-global_quality", &self.crf.to_string()]);
             }
             "h264_vaapi" => {
@@ -158,7 +169,7 @@ impl Mp4FfmpegCliEncoder {
             }
             _ => {
                 // Default libx264 settings
-                command.args(["-preset", "fast"]);
+                command.args(["-preset", preset]);
                 command.args(["-crf", &self.crf.to_string()]);
             }
         }


### PR DESCRIPTION
This update the CLI encoder to enable direct encoding and hardware usage.
It uses a pipe to Ffmpeg to stream frames and encode without saving to disk.